### PR TITLE
mssql - Changed the parameter of the tvp factory to be omitted

### DIFF
--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -32,7 +32,7 @@ export interface ISqlTypeFactoryWithNoParams extends ISqlTypeFactory { (): ISqlT
 export interface ISqlTypeFactoryWithLength extends ISqlTypeFactory { (length?: number): ISqlTypeWithLength }
 export interface ISqlTypeFactoryWithScale extends ISqlTypeFactory { (scale?: number): ISqlTypeWithScale }
 export interface ISqlTypeFactoryWithPrecisionScale extends ISqlTypeFactory { (precision?: number, scale?: number): ISqlTypeWithPrecisionScale; }
-export interface ISqlTypeFactoryWithTvpType extends ISqlTypeFactory { (tvpType: any): ISqlTypeWithTvpType }
+export interface ISqlTypeFactoryWithTvpType extends ISqlTypeFactory { (tvpType?: any): ISqlTypeWithTvpType }
 
 
 export declare var VarChar: ISqlTypeFactoryWithLength;


### PR DESCRIPTION
Please fill in this template.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/mssql/index.d.ts
https://github.com/tediousjs/node-mssql/blob/master/lib/base/request.js#L106

This is probably just an oversight, but the factory of the TVP type does require to pass a TvpType in, while the package doesn't need it. Even if you compare it with the other type factories, they are following the same pattern as not requiring parameters if the factory is called without them.